### PR TITLE
Make all text translatable (fixes #4)

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -1,0 +1,47 @@
+en:
+  Bigfork\SilverstripeUserFormsTidying\Extensions\EditableCheckboxExtension:
+    DEFAULT_VALUE: 'Default value'
+  Bigfork\SilverstripeUserFormsTidying\Extensions\EditableFormFieldExtension:
+    SHOW_IN_SUMMARY: 'Show this field in the “summary” column for submissions'
+    SUMMARY_FIELD: 'Summary field'
+    DESCRIPTION_LABEL: 'Description'
+    DESCRIPTION_DESCRIPTION: 'Text to help guide the user on how to fill out the field'
+    ADVANCED: 'Advanced'
+    DEFAULTVALUE_DESCRIPTION: 'Value to pre-populate the field with'
+    PLACEHOLDER_DESCRIPTION: 'Shows the user an example value'
+    REQUIRED_LABEL: 'Required field'
+    REQUIRED_DESCRIPTION: 'Make this a required field'
+    CUSTOMERROR_LABEL: 'Custom error message'
+    CUSTOMERROR_DESCRIPTION: 'The error message shown when the user doesn’t complete this field'
+  Bigfork\SilverstripeUserFormsTidying\Extensions\EditableDateFieldExtension:
+    PREPOPULATE: 'Pre-populate the field with today’s date'
+    DEFAULTTOTODAY: 'Default to today'
+  Bigfork\SilverstripeUserFormsTidying\Extensions\EditableCountryDropdownFieldExtension:
+    CHOOSECOUNTRY: 'Select a country...'
+    EMPTYSTRING_CHECKBOX_LABEL: 'Empty value'
+    EMPTYSTRING_CHECKBOX_DESCRIPTION: 'Display custom text when no country has been selected'
+    EMPTYSTRING_LABEL: 'Empty value text'
+    EMPTYSTRING_DESCRIPTION: 'Shown when no country has been selected'
+  Bigfork\SilverstripeUserFormsTidying\Extensions\EditableLiteralFieldExtension:
+    HIDEFROMREPORTS_LABEL: 'Hide from reports?'
+    HIDEFROMREPORTS_DESCRIPTION: 'Stop this field showing in stored submissions'
+  Bigfork\SilverstripeUserFormsTidying\Extensions\EditableMultipleOptionFieldExtension:
+    ADD_OPTION: 'Add new option'
+    EMPTYSTRING_CHECKBOX_DESCRIPTION: 'Display custom text when no value has been selected'
+    EMPTYSTRING_CHECKBOX_LABEL: 'Empty value'
+    EMPTYSTRING_LABEL: 'Empty value text'
+    EMPTYSTRING_DESCRIPTION: 'Shown when no value has been selected'
+  Bigfork\SilverstripeUserFormsTidying\Extensions\UserFormCMSFieldsExtension:
+    FIELDOVERVIEW_FIELDTYPE: 'Field type'
+    FIELDOVERVIEW_TITLE: 'Title'
+    FIELDOVERVIEW_REQUIRED: 'Required'
+    FIELDOVERVIEW_SHOWINSUMMARY: 'Show in summary?'
+    FIELDOVERVIEW_ADDFIELD: 'Add form field'
+    FIELDOVERVIEW_ADDPAGEBREAK: 'Add page break'
+    FIELDOVERVIEW_ADDGROUPFIELD: 'Add field group'
+    CONFIGURATION_SHOWONCOMPLETE: 'Show on completion'
+    CONFIGURATION_SUBMITLABEL: 'Submit button text'
+    CONFIGURATION_SUBMITPLACEHOLDER: 'Submit'
+    CONFIGURATION_SAVESUBMISSIONS: 'Save submissions to CMS?'
+    CONFIGURATION_SAVESUBMISSIONS_YES: 'Yes'
+    CONFIGURATION_SAVESUBMISSIONS_NO: 'No'

--- a/lang/nl.yml
+++ b/lang/nl.yml
@@ -1,0 +1,47 @@
+nl:
+  Bigfork\SilverstripeUserFormsTidying\Extensions\EditableCheckboxExtension:
+    DEFAULT_VALUE: 'Gedrag'
+  Bigfork\SilverstripeUserFormsTidying\Extensions\EditableFormFieldExtension:
+    SHOW_IN_SUMMARY: 'Toon dit veld in het overzicht van inzendingen'
+    SUMMARY_FIELD: 'Overzicht'
+    DESCRIPTION_LABEL: 'Toelichting'
+    DESCRIPTION_DESCRIPTION: 'Tips hoe de gebruiker dit veld in kan vullen'
+    ADVANCED: 'Overige instellingen'
+    DEFAULTVALUE_DESCRIPTION: 'Waarde om het veld standaard mee te vullen'
+    PLACEHOLDER_DESCRIPTION: 'Toont de gebruiker een voorbeeld waarde'
+    REQUIRED_LABEL: 'Verplicht veld'
+    REQUIRED_DESCRIPTION: 'Maak dit een verplicht veld'
+    CUSTOMERROR_LABEL: 'Aangepaste foutmelding'
+    CUSTOMERROR_DESCRIPTION: 'Dit bericht wordt getoond als het veld niet (correct) wordt ingevuld'
+  Bigfork\SilverstripeUserFormsTidying\Extensions\EditableDateFieldExtension:
+    PREPOPULATE: 'Veld standaard instellen op huidige datum'
+    DEFAULTTOTODAY: 'Standaard op vandaag'
+  Bigfork\SilverstripeUserFormsTidying\Extensions\EditableCountryDropdownFieldExtension:
+    CHOOSECOUNTRY: 'Kies een land...'
+    EMPTYSTRING_CHECKBOX_LABEL: 'Lege waarde'
+    EMPTYSTRING_CHECKBOX_DESCRIPTION: 'Toon een tekst als er nog geen land gekozen is...'
+    EMPTYSTRING_LABEL: 'Tekst bij lege waarde'
+    EMPTYSTRING_DESCRIPTION: 'Wordt getoond als er nog geen land is gekozen'
+  Bigfork\SilverstripeUserFormsTidying\Extensions\EditableLiteralFieldExtension:
+    HIDEFROMREPORTS_LABEL: 'Verberg in overzichten?'
+    HIDEFROMREPORTS_DESCRIPTION: 'Dit veld niet tonen e-mails en detailweergave van inzending'
+  Bigfork\SilverstripeUserFormsTidying\Extensions\EditableMultipleOptionFieldExtension:
+    ADD_OPTION: 'Optie toevoegen'
+    EMPTYSTRING_CHECKBOX_LABEL: 'Lege waarde'
+    EMPTYSTRING_CHECKBOX_DESCRIPTION: 'Toon een tekst als er nog geen keuze gemaakt is...'
+    EMPTYSTRING_LABEL: 'Tekst bij lege waarde'
+    EMPTYSTRING_DESCRIPTION: 'Wordt getoond als er nog geen keuze gemaakt is'
+  Bigfork\SilverstripeUserFormsTidying\Extensions\UserFormCMSFieldsExtension:
+    FIELDOVERVIEW_FIELDTYPE: 'Soort veld'
+    FIELDOVERVIEW_TITLE: 'Titel'
+    FIELDOVERVIEW_REQUIRED: 'Verplicht?'
+    FIELDOVERVIEW_SHOWINSUMMARY: 'Toon in overzicht?'
+    FIELDOVERVIEW_ADDFIELD: 'Nieuw veld toevoegen'
+    FIELDOVERVIEW_ADDPAGEBREAK: 'Nieuwe pagina toevoegen'
+    FIELDOVERVIEW_ADDGROUPFIELD: 'Veldgroep toevoegen'
+    CONFIGURATION_SHOWONCOMPLETE: 'Melding na succesvolle inzending'
+    CONFIGURATION_SUBMITLABEL: 'Tekst op verzend-knop'
+    CONFIGURATION_SUBMITPLACEHOLDER: 'Verstuur'
+    CONFIGURATION_SAVESUBMISSIONS: 'Formulier inzendingen opslaan in CMS'
+    CONFIGURATION_SAVESUBMISSIONS_YES: 'Ja'
+    CONFIGURATION_SAVESUBMISSIONS_NO: 'Nee'

--- a/src/Extensions/EditableCheckboxExtension.php
+++ b/src/Extensions/EditableCheckboxExtension.php
@@ -6,6 +6,7 @@ use SilverStripe\Core\Extension;
 use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\FieldGroup;
 use SilverStripe\Forms\FieldList;
+use SilverStripe\UserForms\Model;
 
 class EditableCheckboxExtension extends Extension
 {
@@ -15,8 +16,8 @@ class EditableCheckboxExtension extends Extension
             'CheckedDefault',
             FieldGroup::create(
                 'Default value',
-                CheckboxField::create('CheckedDefault', 'This checkbox should be checked by default')
-            )
+                CheckboxField::create('CheckedDefault', _t(EditableFormField::class . '.CHECKEDBYDEFAULT', 'Checked by Default?'))
+            )->setTitle(_t(__CLASS__.'.DEFAULT_VALUE', 'Default value'))
         );
     }
 }

--- a/src/Extensions/EditableCountryDropdownFieldExtension.php
+++ b/src/Extensions/EditableCountryDropdownFieldExtension.php
@@ -15,7 +15,7 @@ class EditableCountryDropdownFieldExtension extends Extension
     {
         /** @var DropdownField $default */
         $default = $fields->dataFieldByName('Default');
-        $default->setEmptyString('Select a country...');
+        $default->setEmptyString(_t(__CLASS__.'.CHOOSECOUNTRY', 'Select a country...'));
 
         $fields->removeByName(['UseEmptyString', 'EmptyString']);
         $fields->addFieldsToTab(
@@ -23,10 +23,10 @@ class EditableCountryDropdownFieldExtension extends Extension
             [
                 FieldGroup::create(
                     'Empty value',
-                    CheckboxField::create('UseEmptyString', 'Display custom text when no country has been selected')
-                ),
-                $emptyString = TextField::create('EmptyString', 'Empty value text')
-                    ->setDescription('Shown when no country has been selected')
+                    CheckboxField::create('UseEmptyString', _t(__CLASS__.'.EMPTYSTRING_CHECKBOX_DESCRIPTION', 'Display custom text when no country has been selected'))
+                )->setTitle(_t(__CLASS__.'.EMPTYSTRING_CHECKBOX_LABEL', 'Empty value')),
+                $emptyString = TextField::create('EmptyString', _t(__CLASS__.'.EMPTYSTRING_LABEL', 'Empty value text'))
+                    ->setDescription(_t(__CLASS__.'.EMPTYSTRING_DESCRIPTION', 'Shown when no country has been selected'))
             ],
             'Advanced'
         );

--- a/src/Extensions/EditableDateFieldExtension.php
+++ b/src/Extensions/EditableDateFieldExtension.php
@@ -15,8 +15,8 @@ class EditableDateFieldExtension extends Extension
             'DefaultToToday',
             FieldGroup::create(
                 'Default to today',
-                CheckboxField::create('DefaultToToday', 'Pre-populate the field with today’s date')
-            )
+                CheckboxField::create('DefaultToToday', _t(__CLASS__.'.PREPOPULATE', 'Pre-populate the field with today’s date'))
+            )->setTitle(_t(__CLASS__.'.DEFAULTTOTODAY', 'Default to today'))
         );
     }
 }

--- a/src/Extensions/EditableFormFieldExtension.php
+++ b/src/Extensions/EditableFormFieldExtension.php
@@ -24,8 +24,8 @@ class EditableFormFieldExtension extends Extension
             'ShowInSummary',
             FieldGroup::create(
                 'Summary field',
-                CheckboxField::create('ShowInSummary', 'Show this field in the “summary” column for submissions')
-            )
+                CheckboxField::create('ShowInSummary', _t(__CLASS__.'.SHOW_IN_SUMMARY', 'Show this field in the “summary” column for submissions'))
+            )->setTitle(_t(__CLASS__.'.SUMMARY_FIELD', 'Summary field'))
         );
 
         // Remove right title - description makes this redundant
@@ -35,17 +35,17 @@ class EditableFormFieldExtension extends Extension
         if (!$this->owner->config()->get('literal')) {
             $fields->insertAfter(
                 'Title',
-                TextField::create('Description', 'Description')
-                    ->setDescription('Text to help guide the user on how to fill out the field')
+                TextField::create('Description', _t(__CLASS__.'.DESCRIPTION_LABEL', 'Description'))
+                    ->setDescription(_t(__CLASS__.'.DESCRIPTION_DESCRIPTION', 'Text to help guide the user on how to fill out the field'))
             );
         }
 
         // Add hints for CMS users about existing fields
         if ($defaultValue = $fields->dataFieldByName('Default')) {
-            $defaultValue->setDescription('Value to pre-populate the field with');
+            $defaultValue->setDescription(_t(__CLASS__.'.DEFAULTVALUE_DESCRIPTION', 'Value to pre-populate the field with'));
         }
         if ($placeholder = $fields->dataFieldByName('Placeholder')) {
-            $placeholder->setDescription('Shows the user an example value');
+            $placeholder->setDescription(_t(__CLASS__.'.PLACEHOLDER_DESCRIPTION', 'Shows the user an example value'));
         }
 
         // Move validation settings to main tab
@@ -59,18 +59,19 @@ class EditableFormFieldExtension extends Extension
 
             $requiredField = $fields->dataFieldByName('Required');
             if ($requiredField) {
-                $requiredField->setTitle('Make this a required field');
+                $requiredField->setTitle(_t(__CLASS__.'.REQUIRED_DESCRIPTION', 'Make this a required field'));
                 $fields->replaceField(
                     'Required',
                     FieldGroup::create('Required field', $requiredField)
                         ->setName('Required')
+                        ->setTitle(_t(__CLASS__.'.REQUIRED_LABEL', 'Required field'))
                 );
             }
 
             $customErrorMessage = $fields->dataFieldByName('CustomErrorMessage');
             if ($customErrorMessage) {
-                $customErrorMessage->setTitle('Custom error message');
-                $customErrorMessage->setDescription('The error message shown when the user doesn’t complete this field');
+                $customErrorMessage->setTitle(_t(__CLASS__.'.CUSTOMERROR_LABEL', 'Custom error message'));
+                $customErrorMessage->setDescription(_t(__CLASS__.'.CUSTOMERROR_DESCRIPTION', 'The error message shown when the user doesn’t complete this field'));
                 $customErrorMessage->displayIf('Required')->isChecked();
             }
         }
@@ -78,7 +79,7 @@ class EditableFormFieldExtension extends Extension
         // Move fields CMS users will rarely need to an "Advanced" toggle section
         $fields->addFieldToTab(
             'Root.Main',
-            $advancedFields = ToggleCompositeField::create('Advanced', 'Advanced', [])
+            $advancedFields = ToggleCompositeField::create('Advanced', _t(__CLASS__.'.ADVANCED', 'Advanced'), [])
         );
         $advancedFieldNames = [
             'Name',

--- a/src/Extensions/EditableFormHeadingExtension.php
+++ b/src/Extensions/EditableFormHeadingExtension.php
@@ -15,8 +15,8 @@ class EditableFormHeadingExtension extends Extension
             'HideFromReports',
             FieldGroup::create(
                 'Hide from reports?',
-                CheckboxField::create('HideFromReports', 'Stop this field showing in stored submissions')
-            )
+                CheckboxField::create('HideFromReports', _t(EditableLiteralFieldExtension::class.'.HIDEFROMREPORTS_DESCRIPTION', 'Stop this field showing in stored submissions'))
+            )->setTitle(_t(EditableLiteralFieldExtension::class.'.HIDEFROMREPORTS_LABEL', 'Hide from reports?'))
         );
     }
 }

--- a/src/Extensions/EditableLiteralFieldExtension.php
+++ b/src/Extensions/EditableLiteralFieldExtension.php
@@ -18,8 +18,8 @@ class EditableLiteralFieldExtension extends Extension
             'HideFromReports',
             FieldGroup::create(
                 'Hide from reports?',
-                CheckboxField::create('HideFromReports', 'Stop this field showing in stored submissions')
-            )
+                CheckboxField::create('HideFromReports', _t(__CLASS__.'.HIDEFROMREPORTS_DESCRIPTION', 'Stop this field showing in stored submissions'))
+            )->setTitle(_t(__CLASS__.'.HIDEFROMREPORTS_LABEL', 'Hide from reports?'))
         );
     }
 }

--- a/src/Extensions/EditableMultipleOptionFieldExtension.php
+++ b/src/Extensions/EditableMultipleOptionFieldExtension.php
@@ -41,7 +41,7 @@ class EditableMultipleOptionFieldExtension extends Extension
 
         /** @var GridFieldAddNewInlineButton $addNewButton */
         $addNewButton = $optionsGridField->getConfig()->getComponentByType(GridFieldAddNewInlineButton::class);
-        $addNewButton->setTitle('Add new option');
+        $addNewButton->setTitle(_t(__CLASS__.'.ADD_OPTION', 'Add new option'));
 
         /** @var GridFieldEditableColumns $editableColumns */
         $editableColumns = $optionsGridField->getConfig()->getComponentByType(GridFieldEditableColumns::class);
@@ -70,10 +70,10 @@ class EditableMultipleOptionFieldExtension extends Extension
                 [
                     FieldGroup::create(
                         'Empty value',
-                        CheckboxField::create('UseEmptyString', 'Display custom text when no value has been selected')
-                    ),
-                    $emptyString = TextField::create('EmptyString', 'Empty value text')
-                        ->setDescription('Shown when no value has been selected')
+                        CheckboxField::create('UseEmptyString', _t(__CLASS__.'.EMPTYSTRING_CHECKBOX_DESCRIPTION', 'Display custom text when no value has been selected'))
+                    )->setTitle(_t(__CLASS__.'.EMPTYSTRING_CHECKBOX_LABEL', 'Empty value')),
+                    $emptyString = TextField::create('EmptyString', _t(__CLASS__.'.EMPTYSTRING_LABEL', 'Empty value text'))
+                        ->setDescription(_t(__CLASS__.'.EMPTYSTRING_DESCRIPTION', 'Shown when no value has been selected'))
                 ],
                 'Advanced'
             );

--- a/src/Extensions/UserFormCMSFieldsExtension.php
+++ b/src/Extensions/UserFormCMSFieldsExtension.php
@@ -59,7 +59,7 @@ class UserFormCMSFieldsExtension extends Extension
         $fieldClasses = singleton(EditableFormField::class)->getEditableFieldClasses();
         $editableColumns->setDisplayFields([
             'ClassName' => [
-                'title' => 'Field type',
+                'title' => _t(__CLASS__.'.FIELDOVERVIEW_FIELDTYPE', 'Field type'),
                 'callback' => function (EditableFormField $record, $column) use ($fieldClasses) {
                     $field = $record->getInlineClassnameField($column, $fieldClasses);
                     $field->setValue(EditableTextField::class);
@@ -72,13 +72,13 @@ class UserFormCMSFieldsExtension extends Extension
                 }
             ],
             'Title' => [
-                'title' => 'Title',
+                'title' => _t(__CLASS__.'.FIELDOVERVIEW_TITLE', 'Title'),
                 'callback' => function (EditableFormField $record, $column) {
                     return $record->getInlineTitleField($column);
                 }
             ],
             'Required' => [
-                'title' => 'Required',
+                'title' => _t(__CLASS__.'.FIELDOVERVIEW_REQUIRED', 'Required'),
                 'callback' => function (EditableFormField $record, $column) {
                     if ($record instanceof EditableFormStep || $record instanceof EditableFieldGroup || $record instanceof EditableFieldGroupEnd) {
                         return HiddenField::create($column);
@@ -88,7 +88,7 @@ class UserFormCMSFieldsExtension extends Extension
                 }
             ],
             'ShowInSummary' => [
-                'title' => 'Show in summary?',
+                'title' => _t(__CLASS__.'.FIELDOVERVIEW_SHOWINSUMMARY', 'Show in summary?'),
                 'callback' => function (EditableFormField $record, $column) {
                     if ($record instanceof EditableFormStep || $record instanceof EditableFieldGroup || $record instanceof EditableFieldGroupEnd) {
                         return HiddenField::create($column);
@@ -103,18 +103,18 @@ class UserFormCMSFieldsExtension extends Extension
 
         $fieldsGridField->getConfig()->addComponent(
             (GridFieldAddNewFormFieldInlineButton::create())
-                ->setTitle('Add form field')
+                ->setTitle(_t(__CLASS__.'.FIELDOVERVIEW_ADDFIELD', 'Add form field'))
         );
         if (!$this->owner->config()->get('disable_multi_step_forms')) {
             $fieldsGridField->getConfig()->addComponent(
                 (GridFieldAddNewPageBreakInlineButton::create())
-                    ->setTitle('Add page break')
+                    ->setTitle(_t(__CLASS__.'.FIELDOVERVIEW_ADDPAGEBREAK', 'Add page break'))
             );
         }
         if (!$this->owner->config()->get('disable_form_field_groups')) {
             $fieldsGridField->getConfig()->addComponent(
                 (GridFieldAddNewFieldGroupInlineButton::create())
-                    ->setTitle('Add field group')
+                    ->setTitle(_t(__CLASS__.'.FIELDOVERVIEW_ADDGROUPFIELD', 'Add field group'))
             );
         }
     }
@@ -125,22 +125,22 @@ class UserFormCMSFieldsExtension extends Extension
         $configuration = $fields->fieldByName('Root.FormOptions');
         $configuration->removeByName('OnCompleteMessageLabelOnCompleteMessage');
         $configuration->unshift(
-            HTMLEditorField::create('OnCompleteMessage', 'Show on completion')
+            HTMLEditorField::create('OnCompleteMessage', _t(__CLASS__.'.CONFIGURATION_SHOWONCOMPLETE', 'Show on completion'))
                 ->setRows(3)
                 ->addExtraClass('stacked')
         );
 
         // Add placeholder to submit button text to show default value
         $fields->dataFieldByName('SubmitButtonText')
-            ->setTitle('Submit button text')
-            ->setAttribute('placeholder', 'Submit');
+            ->setTitle(_t(__CLASS__.'.CONFIGURATION_SUBMITLABEL', 'Submit button text'))
+            ->setAttribute('placeholder', _t(__CLASS__.'.CONFIGURATION_SUBMITPLACEHOLDER', 'Submit'));
 
         // Make "disable save to server" field more user friendly
         $fields->replaceField(
             'DisableSaveSubmissions',
-            DropdownField::create('DisableSaveSubmissions', 'Save submissions to CMS?', [
-                0 => 'Yes',
-                1 => 'No'
+            DropdownField::create('DisableSaveSubmissions', _t(__CLASS__.'.CONFIGURATION_SAVESUBMISSIONS', 'Save submissions to CMS?'), [
+                0 => _t(__CLASS__.'.CONFIGURATION_SAVESUBMISSIONS_YES', 'Yes'),
+                1 => _t(__CLASS__.'.CONFIGURATION_SAVESUBMISSIONS_NO', 'No')
             ])
         );
     }


### PR DESCRIPTION
I've kept all existing strings in place, but made it translable for other languages.